### PR TITLE
Connect Button Suggest Get MetaMask

### DIFF
--- a/components/ConnectButton.vue
+++ b/components/ConnectButton.vue
@@ -3,6 +3,7 @@
     <v-btn
       v-if="auth"
       class="text-none font-weight-bold top-bar-button"
+      :style="{'pointer-events': 'none'}"
     >
       <code>{{ auth.address }}</code>
       <!-- {{ truncatedAddress }} -->
@@ -19,7 +20,7 @@
       :class="{ animate: shouldAnimate }"
       :color="shouldAnimate ? 'red' : 'primary'"
       variant="tonal"
-      @click="connect"
+      @click="suggestMetaMask ? linkToGetMetaMask() : connect()"
     >
       Connect
     </v-btn>
@@ -56,6 +57,10 @@ const connect = async () => {
       ? welcomeLastSeen.value < welcomeDialogUpdated
       : true
   }
+}
+
+const linkToGetMetaMask = () => {
+  window.open("https://metamask.io/download/", '_blank')
 }
 
 const truncatedAddress = computed(() => {

--- a/composables/provider.ts
+++ b/composables/provider.ts
@@ -1,13 +1,28 @@
-import { BrowserProvider, getDefaultProvider } from 'ethers'
+import { BrowserProvider } from 'ethers'
+// import { BrowserProvider, getDefaultProvider } from 'ethers'
 
 const network = 31337 // TODO -> network swapping
+
+export const useSuggestMetaMask = () => useState<boolean | undefined>(
+  'suggest-meta-mask',
+  () => false
+)
+
+export const suggestMetaMask = useSuggestMetaMask()
 
 export const useProvider = () => {
 
   if (process.server || typeof window === 'undefined') {
     return null
   } else if (!window.ethereum) {
-    return getDefaultProvider(31337)
+    suggestMetaMask.value = true
+    return null
+    // try {
+    //   return getDefaultProvider(31337)
+    // } catch {
+    //   suggestMetaMask.value = true
+    //   return null
+    // }
   } else {
     const provider = new BrowserProvider(window.ethereum, 31337)
 


### PR DESCRIPTION
Handling the error with catch block (commented code) doesn't stop a file (ethers -> src.ts -> providers -> default-provider.ts) deep in the node modules from also "console.log"ing the unsupported network error as well (with the stack trace then in the console), so chose to remove getDefaultProvider() altogether. Exposing stack trace from front end code not a huge security concern but a security concern nonetheless...