### PR TITLE
Full width index cards small screens

### DIFF
--- a/composables/layout.ts
+++ b/composables/layout.ts
@@ -8,7 +8,7 @@ export const useNavDrawerOpen = () => useState<boolean | undefined>(
   () => true
 )
 
-const smallScreenWidth = 800
+const smallScreenWidth = 960
 
 export const smallScreen = useSmallScreen()
 export const navDrawerOpen = useNavDrawerOpen()

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,7 +5,12 @@
         <v-col
           v-for="{ key, label, value, icon } in topCards"
           :key="key"
-          cols="6"
+          cols="12"
+          sm="6"
+          md="6"
+          lg="6"
+          xl="6"
+          xxl="3"
         >
           <v-card class="v-card-ator">
             <v-container>


### PR DESCRIPTION
xs attr does not work on <600px screens on desktop, only mobile devices. So cols="12" as default (covers that case- smallest screens on both desktop and mobile) with every other case defined.